### PR TITLE
Fix unsound widening operator for signs domain

### DIFF
--- a/core/src/main/scala/it/unich/jandom/domains/numerical/SignDomain.scala
+++ b/core/src/main/scala/it/unich/jandom/domains/numerical/SignDomain.scala
@@ -168,7 +168,7 @@ class SignDomain extends NumericalDomain {
      * @note @inheritdoc
      * @throws $ILLEGAL
      */
-    def widening(that: Property) = that
+    def widening(that: Property) = that union this
 
     /**
      * This is the standard narrowing on signs, i.e. one that does nothing,


### PR DESCRIPTION
f(x,y) = y is *not* an upper bound operator, therefore not acceptable as
a widening operator (see e.g. Nielson&Nielson&Hankin).

Particularly, the docs for AbstractProperty expressly specify that "that
is NOT assumed to be bigger than this".